### PR TITLE
Add property snippet in JS

### DIFF
--- a/.vscode/test.code-snippets
+++ b/.vscode/test.code-snippets
@@ -91,6 +91,14 @@
 		],
 		"description": "Generate LitElement Property"
 	},
+	"Generate LitElement Property in Javascript": {
+		"scope": "javascript",
+		"prefix": ["property"],
+		"body": [
+			"${1:propName}: { type: ${2|String,Number,Boolean,Array,Object|} },${0}",
+		],
+		"description": "Generate LitElement Property"
+	},
 	"Generate LitElement Properties in Javascript": {
 		"scope": "javascript",
 		"prefix": ["litprop", "properties"],

--- a/.vscode/test.code-snippets
+++ b/.vscode/test.code-snippets
@@ -105,7 +105,7 @@
 		"body": [
 			"static get properties() {",
 			"\treturn {",
-			"\t\t${1:propName}: { type: ${2|String,Number,Boolean,Array,Object|} }${0}",
+			"\t\t${1:propName}: { type: ${2|String,Number,Boolean,Array,Object|} },${0}",
 			"\t};",
 			"}"
 		],

--- a/src/javascript.json
+++ b/src/javascript.json
@@ -47,7 +47,7 @@
     "body": [
       "static get properties() {",
       "\treturn {",
-      "\t\t${1:propName}: { type: ${2|String,Number,Boolean,Array,Object|} }${0}",
+      "\t\t${1:propName}: { type: ${2|String,Number,Boolean,Array,Object|} },${0}",
       "\t};",
       "}"
     ],

--- a/src/javascript.json
+++ b/src/javascript.json
@@ -34,6 +34,14 @@
     ],
     "description": "New LitElement subclass"
   },
+  "Generate LitElement Property in Javascript": {
+		"scope": "javascript",
+		"prefix": ["property"],
+		"body": [
+			"${1:propName}: { type: ${2|String,Number,Boolean,Array,Object|} },${0}"
+		],
+		"description": "Generate LitElement Property"
+	},
   "Generate LitElement Properties": {
     "prefix": ["litprop", "properties"],
     "body": [


### PR DESCRIPTION
Now you can create `properties` static getter with keyword `litprop` and `properties`. Then you can add more field later by typing `property`

PS. This feature only for Javascript 