### PR TITLE
Generate native lifecycle callbacks

### DIFF
--- a/.vscode/test.code-snippets
+++ b/.vscode/test.code-snippets
@@ -230,4 +230,12 @@
 		],
 		"description": "Generate attributeChangedCallback(): Invoked when component attribute changes."
 	},
+	"Generate Observed Attributes": {
+		"scope": "javascript,typescript",
+		"prefix": ["observedattributes"],
+		"body": [
+			"static get observedAttributes() { return ['${1:nameOfAttribute}']; }"
+		],
+		"description": "Generate observedAttributes getter: Returns an array containing the names of the attributes you want to observe."
+	},
 }

--- a/.vscode/test.code-snippets
+++ b/.vscode/test.code-snippets
@@ -174,5 +174,60 @@
 		"body": [
 			"this.dispatchEvent(${1:event});${0}"
 		]
-	}
+	},
+	"Generate Connected Callback": {
+		"scope": "javascript,typescript",
+		"prefix": ["litconnectedcallback", "connectedcallback"],
+		"body": [
+			"connectedCallback() {",
+			"\tsuper.connectedCallback();",
+			"\t${0}",
+			"}"
+		],
+		"description": "Generate connectedCallback(): Invoked when a component is added to the document's DOM."
+	},
+	"Generate Disconnected Callback": {
+		"scope": "javascript,typescript",
+		"prefix": ["litdisconnectedcallback", "disconnectedcallback"],
+		"body": [
+			"disconnectedCallback() {",
+			"\tsuper.disconnectedCallback();",
+			"\t${0}",
+			"}"
+		],
+		"description": "Generate disconnectedCallback(): Invoked when a component is removed from the document's DOM."
+	},
+	"Generate Adopted Callback": {
+		"scope": "javascript,typescript",
+		"prefix": ["litadoptedcallback", "adoptedcallback"],
+		"body": [
+			"adoptedCallback() {",
+			"\tsuper.adoptedCallback();",
+			"\t${0}",
+			"}"
+		],
+		"description": "Generate adoptedCallback(): Invoked when a component is moved to a new document."
+	},
+	"Generate Attribute Changed Callback JavaScript": {
+		"scope": "javascript",
+		"prefix": ["litattributechangedcallback", "attributechangedcallback"],
+		"body": [
+			"attributeChangedCallback(name, oldValue, newValue) {",
+			"\tsuper.attributeChangedCallback(name, oldValue, newValue);",
+			"\t${0}",
+			"}"
+		],
+		"description": "Generate attributeChangedCallback(): Invoked when component attribute changes."
+	},
+	"Generate Attribute Changed Callback TypeScript": {
+		"scope": "typescript",
+		"prefix": ["litattributechangedcallback", "attributechangedcallback"],
+		"body": [
+			"attributeChangedCallback(name: string, oldValue: string, newValue: string) {",
+			"\tsuper.attributeChangedCallback(name, oldValue, newValue);",
+			"\t${0}",
+			"}"
+		],
+		"description": "Generate attributeChangedCallback(): Invoked when component attribute changes."
+	},
 }

--- a/src/common.json
+++ b/src/common.json
@@ -31,5 +31,33 @@
 		"body": [
 			"this.dispatchEvent(${1:event});${0}"
 		]
+    },
+	"Generate Connected Callback": {
+		"prefix": ["litconnectedcallback", "connectedcallback"],
+		"body": [
+			"connectedCallback() {",
+			"\t${0}",
+			"}"
+        ],
+		"description": "Generate connectedCallback(): Invoked when a component is added to the document's DOM."
+    },
+	"Generate Disconnected Callback": {
+		"prefix": ["litdisconnectedcallback", "disconnectedcallback"],
+		"body": [
+			"disconnectedCallback() {",
+			"\t${0}",
+			"}"
+        ],
+        "description": "Generate disconnectedCallback(): Invoked when a component is removed from the document's DOM."
+    },
+	"Generate Adopted Callback": {
+		"prefix": ["litadoptedcallback", "adoptedcallback"],
+		"body": [
+			"adoptedCallback() {",
+			"\tsuper.adoptedCallback();",
+			"\t${0}",
+			"}"
+        ],
+        "description": "Generate adoptedCallback(): Invoked when a component is moved to a new document."
 	}
 }

--- a/src/common.json
+++ b/src/common.json
@@ -59,5 +59,12 @@
 			"}"
         ],
         "description": "Generate adoptedCallback(): Invoked when a component is moved to a new document."
+    },
+    "Generate Observed Attributes": {
+		"prefix": ["observedattributes"],
+		"body": [
+			"static get observedAttributes() { return ['${1:nameOfAttribute}']; }"
+		],
+		"description": "Generate observedAttributes getter: Returns an array containing the names of the attributes you want to observe."
 	}
 }

--- a/src/common.json
+++ b/src/common.json
@@ -41,7 +41,8 @@
 	"Generate Connected Callback": {
 		"prefix": ["litconnectedcallback", "connectedcallback"],
 		"body": [
-			"connectedCallback() {",
+            "connectedCallback() {",
+            "\tsuper.connectedCallback();",
 			"\t${0}",
 			"}"
         ],
@@ -50,7 +51,8 @@
 	"Generate Disconnected Callback": {
 		"prefix": ["litdisconnectedcallback", "disconnectedcallback"],
 		"body": [
-			"disconnectedCallback() {",
+            "disconnectedCallback() {",
+            "\tsuper.disconnectedCallback();",
 			"\t${0}",
 			"}"
         ],

--- a/src/javascript.json
+++ b/src/javascript.json
@@ -70,5 +70,15 @@
       "}${0}"
     ],
     "description": "Generate Elements Query Property"
-  }
+  },
+  "Generate Attribute Changed Callback": {
+		"prefix": ["litattributechangedcallback", "attributechangedcallback"],
+		"body": [
+			"attributeChangedCallback(name, oldValue, newValue) {",
+			"\tsuper.attributeChangedCallback(name, oldValue, newValue);",
+			"\t${0}",
+			"}"
+    ],
+    "description": "Generate attributeChangedCallback(): Invoked when component attribute changes."
+	}
 }

--- a/src/typescript.json
+++ b/src/typescript.json
@@ -54,5 +54,15 @@
 		"@queryAll('${1:queryString}') ${2:propName}: NodeListOf<${3:HTMLElement}>;${0}"
 	  ],
 	  "description": "Generate Elements Query Property"
+	},
+	"Generate Attribute Changed Callback": {
+		"prefix": ["litattributechangedcallback", "attributechangedcallback"],
+		"body": [
+			"attributeChangedCallback(name: string, oldValue: string, newValue: string) {",
+			"\tsuper.attributeChangedCallback(name, oldValue, newValue);",
+			"\t${0}",
+			"}"
+		],
+		"description": "Generate attributeChangedCallback(): Invoked when component attribute changes."
 	}
 }


### PR DESCRIPTION
Should resolve all in [#17, #18, #21, `attributeChangedCallback`, `observedAttributes` getter]