### PR TITLE
Categorize snippets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 
 LitElement snippet for Visual Studio Code.
 
-## Screenshot
-#### Javascript
+## Screenshots
+#### JavaScript
 ![Javascript Demo](https://github.com/zarewoft/lit-element-snippet/raw/master/images/screenshot-js.gif)
 
-#### Typescript
+#### TypeScript
 ![Typescript Demo](https://github.com/zarewoft/lit-element-snippet/raw/master/images/screenshot-ts.gif)
 
 ## Features
 
-* LitElement snippet for both javascript and typescript
+* Supports both JavaScript and TypeScript
 
-## LitElement Snippets
+## List
 
+### Element and Its Property Snippets
 | Trigger           | Snippet                                     |
 |-------------------|---------------------------------------------|
 | litele            | Create LitElement subclasss                 |
@@ -22,12 +23,38 @@ LitElement snippet for Visual Studio Code.
 | litprop           | Generate property                           |
 | litrender         | Generate render function with lit-html      |
 | litstyle          | Generate `styles` static property           |
+
+
+### Event Related Snippets
+
+| Trigger           | Snippet                                     |
+|-------------------|---------------------------------------------|
 | addeventlistener  | Generate component's event listener         |
 | customevent       | Generate new CustomEvent                    |
+| dispatchevent     | Generate dispatch of the event              |
+
+
+### Custom Element [Lifecycle Callback](https://developers.google.com/web/fundamentals/web-components/customelements#reactions) Snippets
+
+| Trigger                  | Snippet                                     |
+|--------------------------|---------------------------------------------|
+| connectedcallback        | Generate `connectedCallback()`              |
+| disconnectedcallback     | Generate `disconnectedCallback()`           |
+| adoptedcallback          | Generate `adoptedCallback()`                |
+| attributechangedcallback | Generate `attributechangedCallback(_,_,_)`  |
+| observedattributes       | Generate `static get observedAttributes()` see [Observing changes to attributes](https://developers.google.com/web/fundamentals/web-components/customelements#attrchanges) |
+
+
+### Other Snippets
+
+| Trigger           | Snippet                             |
+|-------------------|-------------------------------------|
+| importele         | Import other element                |
+
 
 ## Contact
 
-Please file any [issues](https://github.com/zarewoft/lit-element-snippet/issues) or have a suggestion please tweet us [@zarewoft](https://twitter.com/zarewoft).
+Please file any [issues](https://github.com/zarewoft/lit-element-snippet/issues) or for any suggestions, please tweet us [@zarewoft](https://twitter.com/zarewoft).
 
 
 ## License


### PR DESCRIPTION
I added new snippets to README and saw the need of separate them to each categories. Let me know what you think.